### PR TITLE
[REEF-1292] Link and StreamingLink classes should have retry logic for setting up remote connection

### DIFF
--- a/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/Org.Apache.REEF.Network.Tests.csproj
@@ -49,6 +49,7 @@ under the License.
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TcpClientConfigurationModuleTests.cs" />
     <Compile Include="BlockingCollectionExtensionTests.cs" />
     <Compile Include="GroupCommunication\GroupCommuDriverTests.cs" />
     <Compile Include="GroupCommunication\GroupCommunicationTests.cs" />

--- a/lang/cs/Org.Apache.REEF.Network.Tests/TcpClientConfigurationModuleTests.cs
+++ b/lang/cs/Org.Apache.REEF.Network.Tests/TcpClientConfigurationModuleTests.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Wake.Remote;
+using Xunit;
+
+namespace Org.Apache.REEF.Network.Tests
+{
+    public class TcpClientConfigurationModuleTests
+    {
+        [Fact]
+        public void TestConfiguration()
+        {
+            int maxConnectionRetries = 5;
+            int sleepTimeinMs = 300;
+
+            var tcpClientFactory =
+                TangFactory.GetTang()
+                    .NewInjector(
+                        TcpClientConfigurationModule.ConfigurationModule
+                            .Set(TcpClientConfigurationModule.MaxConnectionRetry, maxConnectionRetries.ToString())
+                            .Set(TcpClientConfigurationModule.SleepTime, sleepTimeinMs.ToString())
+                            .Build())
+                    .GetInstance<ITcpClientConnectionFactory>();
+            Assert.NotNull(tcpClientFactory);
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
+++ b/lang/cs/Org.Apache.REEF.Network/Org.Apache.REEF.Network.csproj
@@ -155,6 +155,8 @@ under the License.
     <Compile Include="NetworkService\NsMessage.cs" />
     <Compile Include="NetworkService\StreamingNetworkService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TcpClientConfigurationModule.cs" />
+    <Compile Include="TcpClientConfigurationProvider.cs" />
     <Compile Include="Utilities\BlockingCollectionExtensions.cs" />
     <Compile Include="Utilities\Utils.cs" />
   </ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Network/TcpClientConfigurationModule.cs
+++ b/lang/cs/Org.Apache.REEF.Network/TcpClientConfigurationModule.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Common.Client.Parameters;
+using Org.Apache.REEF.Tang.Formats;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Tang.Util;
+using Org.Apache.REEF.Wake.Remote.Parameters;
+
+namespace Org.Apache.REEF.Network
+{
+    /// <summary>
+    /// Configuration Module for the TCP Client provider
+    /// </summary>
+    public class TcpClientConfigurationModule : ConfigurationModuleBuilder
+    {
+        /// <summary>
+        /// Number of times to retry the connection
+        /// </summary>
+        public static readonly OptionalParameter<int> MaxConnectionRetry = new OptionalParameter<int>();
+
+        /// <summary>
+        /// SLeep time between tries in milliseconds.
+        /// </summary>
+        public static readonly OptionalParameter<int> SleepTime = new OptionalParameter<int>();
+
+        public static readonly ConfigurationModule ConfigurationModule = new TcpClientConfigurationModule()
+            .BindSetEntry<DriverConfigurationProviders, TcpClientConfigurationProvider, IConfigurationProvider>(
+                GenericType<DriverConfigurationProviders>.Class, GenericType<TcpClientConfigurationProvider>.Class)
+            .BindNamedParameter(GenericType<ConnectionRetryCount>.Class, MaxConnectionRetry)
+            .BindNamedParameter(GenericType<SleepTimeInMs>.Class, SleepTime)
+            .Build();
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Network/TcpClientConfigurationProvider.cs
+++ b/lang/cs/Org.Apache.REEF.Network/TcpClientConfigurationProvider.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Common.Evaluator.Parameters;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Tang.Interface;
+using Org.Apache.REEF.Wake.Remote.Parameters;
+
+namespace Org.Apache.REEF.Network
+{
+    /// <summary>
+    /// Configuration provider for TcpClient connection.
+    /// </summary>
+    public sealed class TcpClientConfigurationProvider : IConfigurationProvider
+    {
+        private readonly IConfiguration _configuration;
+        
+        [Inject]
+        private TcpClientConfigurationProvider(
+            [Parameter(typeof(ConnectionRetryCount))] int connectionRetryCount,
+            [Parameter(typeof(SleepTimeInMs))] int sleepTimeInMs)
+        {
+            _configuration = TangFactory.GetTang().NewConfigurationBuilder()
+                .BindIntNamedParam<ConnectionRetryCount>(connectionRetryCount.ToString())
+                .BindIntNamedParam<SleepTimeInMs>(sleepTimeInMs.ToString())
+                .BindSetEntry<EvaluatorConfigurationProviders, TcpClientConfigurationProvider, IConfigurationProvider>()
+                .Build();
+        }
+
+        IConfiguration IConfigurationProvider.GetConfiguration()
+        {
+            return _configuration;
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/Org.Apache.REEF.Wake.Tests.csproj
@@ -52,6 +52,7 @@ under the License.
     <Compile Include="StreamingRemoteManagerTest.cs" />
     <Compile Include="StreamingTransportTest.cs" />
     <Compile Include="TimeTest.cs" />
+    <Compile Include="TcpConnectionRetryTest.cs" />
     <Compile Include="TransportTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/TcpConnectionRetryTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/TcpConnectionRetryTest.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using System.IO;
+using System.Net;
+using Org.Apache.REEF.Tang.Implementations.Tang;
+using Org.Apache.REEF.Wake.Remote;
+using Org.Apache.REEF.Wake.Remote.Parameters;
+using Xunit;
+
+namespace Org.Apache.REEF.Wake.Tests
+{
+    public class TcpConnectionRetryTest
+    {
+        /// <summary>
+        /// Tests whether retry logic in RemoteConnectionRetryHandler is called.
+        /// We run just client but not server and then check redirected output for 
+        /// retry messages
+        /// </summary>
+        [Fact]
+        public void TestConnectionRetries()
+        {
+            IPAddress localIpAddress = IPAddress.Parse("127.0.0.1");
+            const int retryCount = 5;
+            const int sleepTimeInMs = 500;
+            IPEndPoint remoteEndpoint = new IPEndPoint(localIpAddress, 8900);
+            var memStream = new MemoryStream();
+            var writer = new StreamWriter(memStream);
+            Console.SetOut(writer);
+            var config =
+                TangFactory.GetTang()
+                    .NewConfigurationBuilder()
+                    .BindIntNamedParam<ConnectionRetryCount>(retryCount.ToString())
+                    .BindIntNamedParam<SleepTimeInMs>(sleepTimeInMs.ToString())
+                    .Build();
+            var tmp = TangFactory.GetTang().NewInjector(config).GetInstance<ITcpClientConnectionFactory>();
+
+            try
+            {
+                tmp.Connect(remoteEndpoint);
+            }
+            catch
+            {
+                memStream.Position = 0;
+                using (var reader = new StreamReader(memStream))
+                {
+                    string line;
+                    int counter = 0;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        if (line.Contains("Retry - Count:"))
+                        {
+                            counter++;
+                        }
+                    }
+                    Assert.Equal(counter, retryCount);
+                }
+            }
+        }
+    }
+}      

--- a/lang/cs/Org.Apache.REEF.Wake.Tests/TcpConnectionRetryTest.cs
+++ b/lang/cs/Org.Apache.REEF.Wake.Tests/TcpConnectionRetryTest.cs
@@ -38,7 +38,9 @@ namespace Org.Apache.REEF.Wake.Tests
             IPAddress localIpAddress = IPAddress.Parse("127.0.0.1");
             const int retryCount = 5;
             const int sleepTimeInMs = 500;
+            const string message = "Retry - Count:";
             IPEndPoint remoteEndpoint = new IPEndPoint(localIpAddress, 8900);
+
             var memStream = new MemoryStream();
             var writer = new StreamWriter(memStream);
             Console.SetOut(writer);
@@ -53,6 +55,7 @@ namespace Org.Apache.REEF.Wake.Tests
             try
             {
                 tmp.Connect(remoteEndpoint);
+                Assert.False(true);
             }
             catch
             {
@@ -63,7 +66,7 @@ namespace Org.Apache.REEF.Wake.Tests
                     int counter = 0;
                     while ((line = reader.ReadLine()) != null)
                     {
-                        if (line.Contains("Retry - Count:"))
+                        if (line.Contains(message))
                         {
                             counter++;
                         }

--- a/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
+++ b/lang/cs/Org.Apache.REEF.Wake/Org.Apache.REEF.Wake.csproj
@@ -30,6 +30,9 @@ under the License.
   </PropertyGroup>
   <Import Project="$(SolutionDir)\build.props" />
   <ItemGroup>
+    <Reference Include="Microsoft.Practices.TransientFaultHandling.Core, Version=5.1.1209.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>$(PackagesDir)\TransientFaultHandling.Core.5.1.1209.1\lib\NET4\Microsoft.Practices.TransientFaultHandling.Core.dll</HintPath>
+    </Reference>
     <Reference Include="protobuf-net">
       <HintPath>$(PackagesDir)\protobuf-net.$(ProtobufVersion)\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
@@ -48,6 +51,8 @@ under the License.
     <Compile Include="IEventHandler.cs" />
     <Compile Include="IIdentifier.cs" />
     <Compile Include="IIdentifierFactory.cs" />
+    <Compile Include="Remote\IConnectionRetryHandler.cs" />
+    <Compile Include="Remote\Impl\RemoteConnectionRetryHandler.cs" />
     <Compile Include="Remote\Impl\RemoteEventStreamingCodec.cs" />
     <Compile Include="Remote\Impl\StreamingRemoteManagerFactory.cs" />
     <Compile Include="Remote\Impl\DefaultRemoteManagerFactory.cs" />
@@ -63,7 +68,11 @@ under the License.
     <Compile Include="IStage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Remote\IRemoteObserver.cs" />
+    <Compile Include="Remote\Impl\TcpClientConnectionFactory.cs" />
+    <Compile Include="Remote\ITcpClientConnectionFactory.cs" />
     <Compile Include="Remote\ITcpPortProvider.cs" />
+    <Compile Include="Remote\Parameters\ConnectionRetryCount.cs" />
+    <Compile Include="Remote\Parameters\SleepTimeInMs.cs" />
     <Compile Include="Remote\Parameters\TcpPortRangeCount.cs" />
     <Compile Include="Remote\Parameters\TcpPortRangeSeed.cs" />
     <Compile Include="Remote\Parameters\TcpPortRangeStart.cs" />

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/IConnectionRetryHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/IConnectionRetryHandler.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Microsoft.Practices.TransientFaultHandling;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Remote.Impl;
+
+namespace Org.Apache.REEF.Wake.Remote
+{
+    /// <summary>
+    /// Interface for the retry logic to connect to remote endpoint
+    /// </summary>
+    [DefaultImplementation(typeof(RemoteConnectionRetryHandler))]
+    public interface IConnectionRetryHandler
+    {
+        /// <summary>
+        /// Retry policy for the tcp connection
+        /// </summary>
+        RetryPolicy Policy { get; }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/ITcpClientConnectionFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/ITcpClientConnectionFactory.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Net;
+using System.Net.Sockets;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Wake.Remote.Impl;
+
+namespace Org.Apache.REEF.Wake.Remote
+{
+    /// <summary>
+    /// Provides TcpClient for the remote endpoint
+    /// </summary>
+    [DefaultImplementation(typeof(TcpClientConnectionFactory))]
+    public interface ITcpClientConnectionFactory
+    {
+        /// <summary>
+        /// Provides TcpClient for the specific endpoint
+        /// </summary>
+        /// <param name="endPoint">IP address and port number of server</param>
+        /// <returns>Tcp client</returns>
+        TcpClient Connect(IPEndPoint endPoint);
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManagerFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/DefaultRemoteManagerFactory.cs
@@ -28,25 +28,49 @@ namespace Org.Apache.REEF.Wake.Impl
     internal sealed class DefaultRemoteManagerFactory : IRemoteManagerFactory
     {
         private readonly ITcpPortProvider _tcpPortProvider;
+        private readonly ITcpClientConnectionFactory _tcpClientFactory;
+
         [Inject]
-        private DefaultRemoteManagerFactory(ITcpPortProvider tcpPortProvider)
+        private DefaultRemoteManagerFactory(ITcpPortProvider tcpPortProvider, ITcpClientConnectionFactory tcpClientFactory)
         {
             _tcpPortProvider = tcpPortProvider;
+            _tcpClientFactory = tcpClientFactory;
         }
 
+        /// <summary>
+        /// Gives DefaultRemoteManager instance
+        /// </summary>
+        /// <typeparam name="T">Type of Message</typeparam>
+        /// <param name="localAddress">Local IP address</param>
+        /// <param name="port">Port number</param>
+        /// <param name="codec">Codec for message type T</param>
+        /// <returns>IRemoteManager instance</returns>
         public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, int port, ICodec<T> codec)
         {
-            return new DefaultRemoteManager<T>(localAddress, port, codec, _tcpPortProvider);
+            return new DefaultRemoteManager<T>(localAddress, port, codec, _tcpPortProvider, _tcpClientFactory);
         }
 
+        /// <summary>
+        /// Gives DefaultRemoteManager instance
+        /// </summary>
+        /// <typeparam name="T">Message type</typeparam>
+        /// <param name="localAddress">Local IP address</param>
+        /// <param name="codec">Codec for message type</param>
+        /// <returns>IRemoteManager instance</returns>
         public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, ICodec<T> codec)
         {
-            return new DefaultRemoteManager<T>(localAddress, 0, codec, _tcpPortProvider);
+            return new DefaultRemoteManager<T>(localAddress, 0, codec, _tcpPortProvider, _tcpClientFactory);
         }
 
+        /// <summary>
+        /// Gives DefaultRemoteManager instance
+        /// </summary>
+        /// <typeparam name="T">Message type</typeparam>
+        /// <param name="codec">Codec for message type</param>
+        /// <returns>IRemoteManager instance</returns>
         public IRemoteManager<T> GetInstance<T>(ICodec<T> codec)
         {
-            return new DefaultRemoteManager<T>(codec);
+            return new DefaultRemoteManager<T>(codec, _tcpClientFactory);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/Link.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/Link.cs
@@ -58,9 +58,6 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
             }
 
             Client = tcpClientFactory.Connect(remoteEndpoint);
-            
-            /*Client = new TcpClient();
-            Client.Connect(remoteEndpoint);*/
 
             _codec = codec;
             _channel = new Channel(Client.GetStream());

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/Link.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/Link.cs
@@ -45,7 +45,8 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// </summary>
         /// <param name="remoteEndpoint">The remote endpoint to connect to</param>
         /// <param name="codec">The codec for serializing messages</param>
-        public Link(IPEndPoint remoteEndpoint, ICodec<T> codec)
+        /// <param name="tcpClientFactory">TcpClient factory</param>
+        public Link(IPEndPoint remoteEndpoint, ICodec<T> codec, ITcpClientConnectionFactory tcpClientFactory)
         {
             if (remoteEndpoint == null)
             {
@@ -56,8 +57,10 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
                 throw new ArgumentNullException("codec");
             }
 
-            Client = new TcpClient();
-            Client.Connect(remoteEndpoint);
+            Client = tcpClientFactory.Connect(remoteEndpoint);
+            
+            /*Client = new TcpClient();
+            Client.Connect(remoteEndpoint);*/
 
             _codec = codec;
             _channel = new Channel(Client.GetStream());

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/RemoteConnectionRetryHandler.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/RemoteConnectionRetryHandler.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System;
+using Microsoft.Practices.TransientFaultHandling;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities.Logging;
+using Org.Apache.REEF.Wake.Remote.Parameters;
+
+namespace Org.Apache.REEF.Wake.Remote.Impl
+{
+    /// <summary>
+    /// Handles the retry logic to connect to remote endpoint
+    /// </summary>
+    internal sealed class RemoteConnectionRetryHandler : IConnectionRetryHandler
+    {
+        private static readonly Logger Logger = Logger.GetLogger(typeof(RemoteConnectionRetryHandler));
+        private readonly RetryPolicy<AllErrorsTransientStrategy> _retryPolicy;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="retryCount">Number of times to retry connection</param>
+        /// <param name="timeIntervalInMs">Time interval between retries in milli seconds</param>
+        [Inject]
+        internal RemoteConnectionRetryHandler([Parameter(typeof(ConnectionRetryCount))] int retryCount,
+            [Parameter(typeof(SleepTimeInMs))] int timeIntervalInMs)
+        {
+            var timeIntervalInMs1 = TimeSpan.FromMilliseconds(timeIntervalInMs);
+            _retryPolicy = new RetryPolicy<AllErrorsTransientStrategy>(
+                    new FixedInterval("ConnectionRetries", retryCount, timeIntervalInMs1, true));
+            _retryPolicy.Retrying += (sender, args) =>
+            {
+                // Log details of the retry.
+                var msg = string.Format("Retry - Count:{0}, Delay:{1}, Exception:{2}",
+                    args.CurrentRetryCount,
+                    args.Delay,
+                    args.LastException);
+                Logger.Log(Level.Info, msg);
+            };
+        }
+
+        /// <summary>
+        /// Retry policy for the connection
+        /// </summary>
+        public RetryPolicy Policy
+        {
+            get
+            {
+                return _retryPolicy;
+            }
+        }
+    }
+
+    internal class AllErrorsTransientStrategy : ITransientErrorDetectionStrategy
+    {
+        public bool IsTransient(Exception ex)
+        {
+            return true;
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingLink.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingLink.cs
@@ -57,15 +57,18 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// </summary>
         /// <param name="remoteEndpoint">The remote endpoint to connect to</param>
         /// <param name="streamingCodec">Streaming codec</param>
-        internal StreamingLink(IPEndPoint remoteEndpoint, IStreamingCodec<T> streamingCodec)
+        /// <param name="tcpClientFactory">TcpClient factory</param>
+        internal StreamingLink(IPEndPoint remoteEndpoint, IStreamingCodec<T> streamingCodec, ITcpClientConnectionFactory tcpClientFactory)
         {
             if (remoteEndpoint == null)
             {
                 throw new ArgumentNullException("remoteEndpoint");
             }
 
-            _client = new TcpClient();
-            _client.Connect(remoteEndpoint);
+            _client = tcpClientFactory.Connect(remoteEndpoint);
+
+           /* _client = new TcpClient();
+            _client.Connect(remoteEndpoint);*/
 
             var stream = _client.GetStream();
             _localEndpoint = GetLocalEndpoint();

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingLink.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingLink.cs
@@ -66,10 +66,6 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
             }
 
             _client = tcpClientFactory.Connect(remoteEndpoint);
-
-           /* _client = new TcpClient();
-            _client.Connect(remoteEndpoint);*/
-
             var stream = _client.GetStream();
             _localEndpoint = GetLocalEndpoint();
             _disposed = false;

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingRemoteManagerFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingRemoteManagerFactory.cs
@@ -28,18 +28,29 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
     public sealed class StreamingRemoteManagerFactory
     {
         private readonly ITcpPortProvider _tcpPortProvider;
+        private readonly ITcpClientConnectionFactory _tcpClientFactory;
         private readonly IInjector _injector;
 
-        [Inject]  
-        private StreamingRemoteManagerFactory(ITcpPortProvider tcpPortProvider, IInjector injector)
+        [Inject]
+        private StreamingRemoteManagerFactory(ITcpPortProvider tcpPortProvider,
+            ITcpClientConnectionFactory tcpClientFactory,
+            IInjector injector)
         {
             _tcpPortProvider = tcpPortProvider;
+            _tcpClientFactory = tcpClientFactory;
             _injector = injector;
         }
 
+        /// <summary>
+        /// Gives StreamingRemoteManager instance
+        /// </summary>
+        /// <typeparam name="T">Type of message</typeparam>
+        /// <param name="localAddress">local IP address</param>
+        /// <param name="codec">codec for message type T</param>
+        /// <returns>IRemoteManager instance</returns>
         public IRemoteManager<T> GetInstance<T>(IPAddress localAddress, IStreamingCodec<T> codec)
         {
-            return new StreamingRemoteManager<T>(localAddress, _tcpPortProvider, codec);
+            return new StreamingRemoteManager<T>(localAddress, _tcpPortProvider, codec, _tcpClientFactory);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportClient.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/StreamingTransportClient.cs
@@ -43,11 +43,12 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// </summary>
         /// <param name="remoteEndpoint">The endpoint of the remote server to connect to</param>
         /// <param name="streamingCodec">Streaming codec</param>
-        internal StreamingTransportClient(IPEndPoint remoteEndpoint, IStreamingCodec<T> streamingCodec)
+        /// <param name="clientFactory">TcpClient factory</param>
+        internal StreamingTransportClient(IPEndPoint remoteEndpoint, IStreamingCodec<T> streamingCodec, ITcpClientConnectionFactory clientFactory)
         {
             Exceptions.ThrowIfArgumentNull(remoteEndpoint, "remoteEndpoint", Logger);
 
-            _link = new StreamingLink<T>(remoteEndpoint, streamingCodec);
+            _link = new StreamingLink<T>(remoteEndpoint, streamingCodec, clientFactory);
             _cancellationSource = new CancellationTokenSource();
             _disposed = false;
         }
@@ -59,10 +60,12 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// <param name="remoteEndpoint">The endpoint of the remote server to connect to</param>
         /// <param name="observer">Callback used when receiving responses from remote host</param>
         /// <param name="streamingCodec">Streaming codec</param>
+        /// <param name="clientFactory">TcpClient factory</param>
         internal StreamingTransportClient(IPEndPoint remoteEndpoint,
             IObserver<TransportEvent<T>> observer,
-            IStreamingCodec<T> streamingCodec)
-            : this(remoteEndpoint, streamingCodec)
+            IStreamingCodec<T> streamingCodec, 
+            ITcpClientConnectionFactory clientFactory)
+            : this(remoteEndpoint, streamingCodec, clientFactory)
         {
             _observer = observer;
             Task.Run(() => ResponseLoop());

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TcpClientConnectionFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TcpClientConnectionFactory.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Net;
+using System.Net.Sockets;
+using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities.Logging;
+
+namespace Org.Apache.REEF.Wake.Remote.Impl
+{
+    /// <summary>
+    /// Default implementation of ITcpClientFactory.
+    /// Provides TcpClient for the remote endpoint with 
+    /// the specified retry logic for connection.
+    /// </summary>
+    public sealed class TcpClientConnectionFactory : ITcpClientConnectionFactory
+    {
+        private readonly IConnectionRetryHandler _retryHandler;
+        private static readonly Logger Logger = Logger.GetLogger(typeof(TcpClientConnectionFactory));
+
+        [Inject]
+        private TcpClientConnectionFactory(IConnectionRetryHandler retryHandler)
+        {
+            _retryHandler = retryHandler;
+        }
+
+        /// <summary>
+        /// Provides TcpClient for the specific endpoint with the 
+        /// retry logic provided by the user.
+        /// </summary>
+        /// <param name="endPoint">IP address and port number of server</param>
+        /// <returns>Tcp client</returns>
+        public TcpClient Connect(IPEndPoint endPoint)
+        {
+            TcpClient client = new TcpClient();
+
+            try
+            {
+                _retryHandler.Policy.ExecuteAction(() => client.Connect(endPoint));
+                var msg = string.Format("Connection to endpoint {0} established", endPoint);
+                Logger.Log(Level.Info, msg);
+                return client;
+            }
+            catch
+            {
+                var msg = string.Format("Connection to endpoint {0} failed", endPoint);
+                Logger.Log(Level.Info, msg);
+                throw;
+            }
+        }
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TcpClientConnectionFactory.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TcpClientConnectionFactory.cs
@@ -15,9 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
 using System.Net;
 using System.Net.Sockets;
 using Org.Apache.REEF.Tang.Annotations;
+using Org.Apache.REEF.Utilities.Diagnostics;
 using Org.Apache.REEF.Utilities.Logging;
 
 namespace Org.Apache.REEF.Wake.Remote.Impl
@@ -55,11 +57,11 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
                 Logger.Log(Level.Info, msg);
                 return client;
             }
-            catch
+            catch (Exception e)
             {
                 var msg = string.Format("Connection to endpoint {0} failed", endPoint);
-                Logger.Log(Level.Info, msg);
-                throw;
+                Exceptions.CaughtAndThrow(e, Level.Error, msg, Logger);
+                return null;
             }
         }
     }

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TransportClient.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Impl/TransportClient.cs
@@ -38,7 +38,8 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// </summary>
         /// <param name="remoteEndpoint">The endpoint of the remote server to connect to</param>
         /// <param name="codec">Codec to decode/encode</param>
-        public TransportClient(IPEndPoint remoteEndpoint, ICodec<T> codec) 
+        /// <param name="clientFactory">TcpClient factory</param>
+        public TransportClient(IPEndPoint remoteEndpoint, ICodec<T> codec, ITcpClientConnectionFactory clientFactory) 
         {
             if (remoteEndpoint == null)
             {
@@ -48,8 +49,12 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
             {
                 throw new ArgumentNullException("codec");
             }
+            if (clientFactory == null)
+            {
+                throw new ArgumentNullException("clientFactory");
+            }
 
-            _link = new Link<T>(remoteEndpoint, codec);
+            _link = new Link<T>(remoteEndpoint, codec, clientFactory);
             _cancellationSource = new CancellationTokenSource();
             _disposed = false;
         }
@@ -61,10 +66,12 @@ namespace Org.Apache.REEF.Wake.Remote.Impl
         /// <param name="remoteEndpoint">The endpoint of the remote server to connect to</param>
         /// <param name="codec">Codec to decode/encodec</param>
         /// <param name="observer">Callback used when receiving responses from remote host</param>
-        public TransportClient(IPEndPoint remoteEndpoint, 
-                               ICodec<T> codec, 
-                               IObserver<TransportEvent<T>> observer) 
-                                   : this(remoteEndpoint, codec)
+        /// <param name="clientFactory">TcpClient factory</param>
+        public TransportClient(IPEndPoint remoteEndpoint,
+            ICodec<T> codec,
+            IObserver<TransportEvent<T>> observer,
+            ITcpClientConnectionFactory clientFactory)
+            : this(remoteEndpoint, codec, clientFactory)
         {
             _observer = observer;
             Task.Run(() => ResponseLoop());

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Parameters/ConnectionRetryCount.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Parameters/ConnectionRetryCount.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.Wake.Remote.Parameters
+{
+    [NamedParameter("Number of retries for connecting to endpoint", defaultValue: "20")]
+    public sealed class ConnectionRetryCount : Name<int>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/Remote/Parameters/SleepTimeInMs.cs
+++ b/lang/cs/Org.Apache.REEF.Wake/Remote/Parameters/SleepTimeInMs.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using Org.Apache.REEF.Tang.Annotations;
+
+namespace Org.Apache.REEF.Wake.Remote.Parameters
+{
+    [NamedParameter("Sleep Time in milliseconds between retries", defaultValue: "1000")]
+    public sealed class SleepTimeInMs : Name<int>
+    {
+    }
+}

--- a/lang/cs/Org.Apache.REEF.Wake/packages.config
+++ b/lang/cs/Org.Apache.REEF.Wake/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -22,4 +22,5 @@ under the License.
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net45" developmentDependency="true" />
+  <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This addressed the issue by
- introducing RemoteConnectionRetryHandler that handles the retry logic for connecting to remote endpoint
- allowing user to specify the value of connection retries and sleep times bewteen retries for NameClient, DefaultRemoteManagerFactory and StreamingRemoteManagerFactory.

JIRA:
  [REEF-1292](https://issues.apache.org/jira/browse/REEF-1292)
